### PR TITLE
Trigger LOG_THROTTLE when time goes backwards (issue #6)

### DIFF
--- a/include/ros/console.h
+++ b/include/ros/console.h
@@ -361,6 +361,12 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
     ROSCONSOLE_PRINT_STREAM_AT_LOCATION_WITH_FILTER(0, args)
 
 /**
+ * \brief Used internally in throttle macros to determine if a new message should be logged.
+ * \note If ROS time has moved backwards, will evaluate to true
+ */
+#define ROSCONSOLE_THROTTLE_CHECK(now, last, period) (ROS_UNLIKELY(last + period <= now) || ROS_UNLIKELY(now < last))
+
+/**
  * \brief Log to a given named logger at a given verbosity level, only if a given condition has been met, with printf-style formatting
  *
  * \note The condition will only be evaluated if this logging statement is enabled
@@ -441,17 +447,17 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
  *
  * \param level One of the levels specified in ::ros::console::levels::Level
  * \param name Name of the logger.  Note that this is the fully qualified name, and does NOT include "ros.<package_name>".  Use ROSCONSOLE_DEFAULT_NAME if you would like to use the default name.
- * \param period The period it should actually trigger at most
+ * \param period The period it should actually trigger at most. If ROS time has moved backwards, it will trigger regardless.
  */
 #define ROS_LOG_THROTTLE(period, level, name, ...) \
   do \
   { \
     ROSCONSOLE_DEFINE_LOCATION(true, level, name); \
     static double last_hit = 0.0; \
-    ::ros::Time now = ::ros::Time::now(); \
-    if (ROS_UNLIKELY(__rosconsole_define_location__enabled) && ROS_UNLIKELY(last_hit + period <= now.toSec())) \
+    double now = ::ros::Time::now().toSec(); \
+    if (ROS_UNLIKELY(__rosconsole_define_location__enabled) && ROSCONSOLE_THROTTLE_CHECK(now, last_hit, period))\
     { \
-      last_hit = now.toSec(); \
+      last_hit = now; \
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
     } \
   } while(false)
@@ -462,17 +468,18 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
  *
  * \param level One of the levels specified in ::ros::console::levels::Level
  * \param name Name of the logger.  Note that this is the fully qualified name, and does NOT include "ros.<package_name>".  Use ROSCONSOLE_DEFAULT_NAME if you would like to use the default name.
- * \param period The period it should actually trigger at most
+ * \param period The period it should actually trigger at most. If ROS time has moved backwards, it will trigger regardless.
  */
 #define ROS_LOG_STREAM_THROTTLE(period, level, name, args) \
   do \
   { \
     ROSCONSOLE_DEFINE_LOCATION(true, level, name); \
     static double __ros_log_stream_throttle__last_hit__ = 0.0; \
-    ::ros::Time __ros_log_stream_throttle__now__ = ::ros::Time::now(); \
-    if (ROS_UNLIKELY(__rosconsole_define_location__enabled) && ROS_UNLIKELY(__ros_log_stream_throttle__last_hit__ + period <= __ros_log_stream_throttle__now__.toSec())) \
+    double __ros_log_stream_throttle__now__ = ::ros::Time::now().toSec(); \
+    if (ROS_UNLIKELY(__rosconsole_define_location__enabled) && \
+        ROSCONSOLE_THROTTLE_CHECK(__ros_log_stream_throttle__now__, __ros_log_stream_throttle__last_hit__, period))\
     { \
-      __ros_log_stream_throttle__last_hit__ = __ros_log_stream_throttle__now__.toSec(); \
+      __ros_log_stream_throttle__last_hit__ = __ros_log_stream_throttle__now__; \
       ROSCONSOLE_PRINT_STREAM_AT_LOCATION(args); \
     } \
   } while(false)
@@ -482,17 +489,18 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
  *
  * \param level One of the levels specified in ::ros::console::levels::Level
  * \param name Name of the logger.  Note that this is the fully qualified name, and does NOT include "ros.<package_name>".  Use ROSCONSOLE_DEFAULT_NAME if you would like to use the default name.
- * \param period The period it should actually trigger at most
+ * \param period The period it should actually trigger at most, and the delay before which no message will be shown. If ROS time has moved backwards, it will trigger regardless.
  */
 #define ROS_LOG_DELAYED_THROTTLE(period, level, name, ...) \
   do \
   { \
     ROSCONSOLE_DEFINE_LOCATION(true, level, name); \
-    ::ros::Time __ros_log_delayed_throttle__now__ = ::ros::Time::now(); \
-    static double __ros_log_delayed_throttle__last_hit__ = __ros_log_delayed_throttle__now__.toSec(); \
-    if (ROS_UNLIKELY(__rosconsole_define_location__enabled) && ROS_UNLIKELY(__ros_log_delayed_throttle__last_hit__ + period <= __ros_log_delayed_throttle__now__.toSec())) \
+    double __ros_log_delayed_throttle__now__ = ::ros::Time::now().toSec(); \
+    static double __ros_log_delayed_throttle__last_hit__ = __ros_log_delayed_throttle__now__; \
+    if (ROS_UNLIKELY(__rosconsole_define_location__enabled) && \
+        ROSCONSOLE_THROTTLE_CHECK(__ros_log_delayed_throttle__now__, __ros_log_delayed_throttle__last_hit__, period))\
     { \
-      __ros_log_delayed_throttle__last_hit__ = __ros_log_delayed_throttle__now__.toSec(); \
+      __ros_log_delayed_throttle__last_hit__ = __ros_log_delayed_throttle__now__; \
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
     } \
   } while(false)
@@ -503,17 +511,18 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
  *
  * \param level One of the levels specified in ::ros::console::levels::Level
  * \param name Name of the logger.  Note that this is the fully qualified name, and does NOT include "ros.<package_name>".  Use ROSCONSOLE_DEFAULT_NAME if you would like to use the default name.
- * \param period The period it should actually trigger at most, and the delay before which no message will be shown.
+ * \param period The period it should actually trigger at most, and the delay before which no message will be shown. If ROS time has moved backwards, it will trigger regardless.
  */
 #define ROS_LOG_STREAM_DELAYED_THROTTLE(period, level, name, args) \
   do \
   { \
     ROSCONSOLE_DEFINE_LOCATION(true, level, name); \
-    ::ros::Time __ros_log_stream_delayed_throttle__now__ = ::ros::Time::now(); \
-    static double __ros_log_stream_delayed_throttle__last_hit__ = __ros_log_stream_delayed_throttle__now__.toSec(); \
-    if (ROS_UNLIKELY(__rosconsole_define_location__enabled) && ROS_UNLIKELY(__ros_log_stream_delayed_throttle__last_hit__ + period <= __ros_log_stream_delayed_throttle__now__.toSec())) \
+    double __ros_log_stream_delayed_throttle__now__ = ::ros::Time::now().toSec(); \
+    static double __ros_log_stream_delayed_throttle__last_hit__ = __ros_log_stream_delayed_throttle__now__; \
+    if (ROS_UNLIKELY(__rosconsole_define_location__enabled) && \
+        ROSCONSOLE_THROTTLE_CHECK(__ros_log_stream_delayed_throttle__now__, __ros_log_stream_delayed_throttle__last_hit__, period)) \
     { \
-      __ros_log_stream_delayed_throttle__last_hit__ = __ros_log_stream_delayed_throttle__now__.toSec(); \
+      __ros_log_stream_delayed_throttle__last_hit__ = __ros_log_stream_delayed_throttle__now__; \
       ROSCONSOLE_PRINT_STREAM_AT_LOCATION(args); \
     } \
   } while(false)


### PR DESCRIPTION
Address issue #6 by adding a  check to the THROTTLE logging macros. If ROS time has moved backwards, trigger a log.