### PR TITLE
Add deregistry function for LogAppender.

### DIFF
--- a/src/rosconsole/impl/rosconsole_glog.cpp
+++ b/src/rosconsole/impl/rosconsole_glog.cpp
@@ -99,7 +99,7 @@ void register_appender(LogAppender* appender)
 
 void deregister_appender(LogAppender* appender)
 {
-  if(rosconsole_glog_appender==appender)
+  if(rosconsole_glog_appender == appender)
   {
     rosconsole_glog_appender = 0;
   }

--- a/src/rosconsole/impl/rosconsole_glog.cpp
+++ b/src/rosconsole/impl/rosconsole_glog.cpp
@@ -97,6 +97,10 @@ void register_appender(LogAppender* appender)
   rosconsole_glog_appender = appender;
 }
 
+void deregister_appender(){
+  rosconsole_glog_appender = NULL;
+}
+
 void shutdown()
 {}
 

--- a/src/rosconsole/impl/rosconsole_glog.cpp
+++ b/src/rosconsole/impl/rosconsole_glog.cpp
@@ -97,8 +97,12 @@ void register_appender(LogAppender* appender)
   rosconsole_glog_appender = appender;
 }
 
-void deregister_appender(){
-  rosconsole_glog_appender = NULL;
+void deregister_appender(LogAppender* appender)
+{
+  if(rosconsole_glog_appender==appender)
+  {
+    rosconsole_glog_appender = 0;
+  }
 }
 
 void shutdown()

--- a/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -369,9 +369,9 @@ void deregister_appender(LogAppender* appender){
 }
 void shutdown()
 {
-  const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
   if(g_log4cxx_appender)
   {
+    const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
     logger->removeAppender(g_log4cxx_appender);
     g_log4cxx_appender = 0;
   }

--- a/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -355,6 +355,7 @@ void register_appender(LogAppender* appender)
 }
 
 void deregister_appender(){
+	const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
  	logger->removeAppender(g_log4cxx_appender);
 	delete g_log4cxx_appender;
 	g_log4cxx_appender = 0;

--- a/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -297,6 +297,10 @@ class Log4cxxAppender : public log4cxx::AppenderSkeleton
 {
 public:
   Log4cxxAppender(ros::console::LogAppender* appender) : appender_(appender) {}
+  const ros::console::LogAppender* getAppender() const
+  {
+    return appender_;
+  }
   ~Log4cxxAppender() {}
 
 protected:
@@ -354,11 +358,14 @@ void register_appender(LogAppender* appender)
   logger->addAppender(g_log4cxx_appender);
 }
 
-void deregister_appender(){
-	const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
- 	logger->removeAppender(g_log4cxx_appender);
-	delete g_log4cxx_appender;
-	g_log4cxx_appender = 0;
+void deregister_appender(LogAppender* appender){
+  if(g_log4cxx_appender->getAppender() == appender)
+  {
+    const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
+    logger->removeAppender(g_log4cxx_appender);
+    delete g_log4cxx_appender;
+    g_log4cxx_appender = 0;
+  }
 }
 void shutdown()
 {

--- a/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -354,6 +354,11 @@ void register_appender(LogAppender* appender)
   logger->addAppender(g_log4cxx_appender);
 }
 
+void deregister_appender(){
+ 	logger->removeAppender(g_log4cxx_appender);
+	delete g_log4cxx_appender;
+	g_log4cxx_appender = 0;
+}
 void shutdown()
 {
   const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);

--- a/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -349,7 +349,7 @@ protected:
   ros::console::LogAppender* appender_;
 };
 
-Log4cxxAppender* g_log4cxx_appender;
+Log4cxxAppender* g_log4cxx_appender = 0;
 
 void register_appender(LogAppender* appender)
 {
@@ -370,8 +370,11 @@ void deregister_appender(LogAppender* appender){
 void shutdown()
 {
   const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
-  logger->removeAppender(g_log4cxx_appender);
-  g_log4cxx_appender = 0;
+  if(g_log4cxx_appender)
+  {
+    logger->removeAppender(g_log4cxx_appender);
+    g_log4cxx_appender = 0;
+  }
   // reset this so that the logger doesn't get crashily destroyed
   // again during global destruction.  
   //

--- a/src/rosconsole/impl/rosconsole_print.cpp
+++ b/src/rosconsole/impl/rosconsole_print.cpp
@@ -71,7 +71,7 @@ void register_appender(LogAppender* appender)
 }
 
 void deregister_appender(LogAppender* appender){
-  if(rosconsole_print_appender==appender)
+  if(rosconsole_print_appender == appender)
   {
     rosconsole_print_appender = 0;
   }

--- a/src/rosconsole/impl/rosconsole_print.cpp
+++ b/src/rosconsole/impl/rosconsole_print.cpp
@@ -70,8 +70,11 @@ void register_appender(LogAppender* appender)
   rosconsole_print_appender = appender;
 }
 
-void deregister_appender(){
-	rosconsole_print_appender = 0;
+void deregister_appender(LogAppender* appender){
+  if(rosconsole_print_appender==appender)
+  {
+    rosconsole_print_appender = 0;
+  }
 }
 
 void shutdown()

--- a/src/rosconsole/impl/rosconsole_print.cpp
+++ b/src/rosconsole/impl/rosconsole_print.cpp
@@ -70,6 +70,10 @@ void register_appender(LogAppender* appender)
   rosconsole_print_appender = appender;
 }
 
+void deregister_appender(){
+	rosconsole_print_appender = 0;
+}
+
 void shutdown()
 {}
 

--- a/src/rosconsole/rosconsole.cpp
+++ b/src/rosconsole/rosconsole.cpp
@@ -63,7 +63,7 @@ void shutdown();
 
 void register_appender(LogAppender* appender);
 
-void deregister_appender();
+void deregister_appender(LogAppender* appender);
 
 void print(void* handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line);
 

--- a/src/rosconsole/rosconsole.cpp
+++ b/src/rosconsole/rosconsole.cpp
@@ -63,6 +63,8 @@ void shutdown();
 
 void register_appender(LogAppender* appender);
 
+void deregister_appender();
+
 void print(void* handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line);
 
 bool isEnabledFor(void* handle, ::ros::console::Level level);


### PR DESCRIPTION
Resolution of [memory leak issue in ROSOutAppender](https://github.com/ros/ros_comm/issues/1433) requires deregistration of `g_rosout_appender`. This PR implements that functionality.