### PR TITLE
Add timestamp formatting for rosconsole

### DIFF
--- a/include/ros/console.h
+++ b/include/ros/console.h
@@ -130,6 +130,8 @@ struct Formatter
 {
   void init(const char* fmt);
   void print(void* logger_handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line);
+  std::string getTokenStrings(void *logger_handle, ::ros::console::Level level, const char *str, const char *file,
+                                const char *function, int line) const;
   std::string format_;
   V_Token tokens_;
 };

--- a/include/ros/console.h
+++ b/include/ros/console.h
@@ -130,8 +130,9 @@ struct Formatter
 {
   void init(const char* fmt);
   void print(void* logger_handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line);
-  std::string getTokenStrings(void *logger_handle, ::ros::console::Level level, const char *str, const char *file,
-                                const char *function, int line) const;
+  std::string getTokenStrings(
+    void *logger_handle, ::ros::console::Level level, const char *str,
+    const char *file, const char *function, int line) const;
   std::string format_;
   V_Token tokens_;
 };

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -1022,12 +1022,8 @@ TEST(RosConsole, formatter)
     ros::console::g_formatter.init(format_string.c_str());
 
     result = ros::console::g_formatter.getTokenStrings(
-            log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME),
-            level,
-            str,
-            file,
-            function,
-            0);
+      log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME), level, str,
+      file, function, 0);
 
     boost::regex expr("([0-9]+)\\.([0-9]+)");
     EXPECT_TRUE(boost::regex_match(result, expr));
@@ -1041,12 +1037,8 @@ TEST(RosConsole, formatter)
     ros::console::g_formatter.init(format_string.c_str());
 
     result = ros::console::g_formatter.getTokenStrings(
-            log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME),
-            level,
-            str,
-            file,
-            function,
-            0);
+      log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME), level, str,
+      file, function, 0);
 
     boost::regex expr("([0-9]{4}) ([0-9]{2}:[0-9]{2}:[0-9]{2})");
     EXPECT_TRUE(boost::regex_match(result, expr));
@@ -1060,12 +1052,8 @@ TEST(RosConsole, formatter)
     ros::console::g_formatter.init(format_string.c_str());
 
     result = ros::console::g_formatter.getTokenStrings(
-            log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME),
-            level,
-            str,
-            file,
-            function,
-            0);
+      log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME), level, str,
+      file, function, 0);
 
     boost::regex expr("([0-9]+)\\.([0-9]+)");
     EXPECT_TRUE(boost::regex_match(result, expr));
@@ -1079,12 +1067,8 @@ TEST(RosConsole, formatter)
     ros::console::g_formatter.init(format_string.c_str());
 
     result = ros::console::g_formatter.getTokenStrings(
-            log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME),
-            level,
-            str,
-            file,
-            function,
-            0);
+      log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME), level, str,
+      file, function, 0);
 
     boost::regex expr("([0-9]{4}) ([0-9]{2}:[0-9]{2}:[0-9]{2})");
     EXPECT_TRUE(boost::regex_match(result, expr));

--- a/test/utest.cpp
+++ b/test/utest.cpp
@@ -42,6 +42,7 @@
 #include <gtest/gtest.h>
 
 #include <boost/shared_array.hpp>
+#include <boost/regex.hpp>
 
 class TestAppender : public log4cxx::AppenderSkeleton
 {
@@ -1000,6 +1001,94 @@ TEST(RosConsole, formatToString)
 {
   std::string str = ros::console::formatToString("Hello World %d", 5);
   EXPECT_STREQ(str.c_str(), "Hello World 5");
+}
+
+TEST(RosConsole, formatter)
+{
+  std::string format_string;
+
+  ros::console::Level level = ros::console::levels::Info;
+  char str[32];
+  char file[32];
+  char function[32];
+
+  std::string result;
+
+  // default time
+  {
+    std::string format_string = "${time}";
+
+    ros::console::g_formatter.tokens_.clear();
+    ros::console::g_formatter.init(format_string.c_str());
+
+    result = ros::console::g_formatter.getTokenStrings(
+            log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME),
+            level,
+            str,
+            file,
+            function,
+            0);
+
+    boost::regex expr("([0-9]+)\\.([0-9]+)");
+    EXPECT_TRUE(boost::regex_match(result, expr));
+  }
+
+  // time format
+  {
+    std::string format_string = "${time:%Y %H:%M:%S}";
+
+    ros::console::g_formatter.tokens_.clear();
+    ros::console::g_formatter.init(format_string.c_str());
+
+    result = ros::console::g_formatter.getTokenStrings(
+            log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME),
+            level,
+            str,
+            file,
+            function,
+            0);
+
+    boost::regex expr("([0-9]{4}) ([0-9]{2}:[0-9]{2}:[0-9]{2})");
+    EXPECT_TRUE(boost::regex_match(result, expr));
+  }
+
+  // default walltime
+  {
+    std::string format_string = "${walltime}";
+
+    ros::console::g_formatter.tokens_.clear();
+    ros::console::g_formatter.init(format_string.c_str());
+
+    result = ros::console::g_formatter.getTokenStrings(
+            log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME),
+            level,
+            str,
+            file,
+            function,
+            0);
+
+    boost::regex expr("([0-9]+)\\.([0-9]+)");
+    EXPECT_TRUE(boost::regex_match(result, expr));
+  }
+
+  // walltime format
+  {
+    std::string format_string = "${walltime:%Y %H:%M:%S}";
+
+    ros::console::g_formatter.tokens_.clear();
+    ros::console::g_formatter.init(format_string.c_str());
+
+    result = ros::console::g_formatter.getTokenStrings(
+            log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME),
+            level,
+            str,
+            file,
+            function,
+            0);
+
+    boost::regex expr("([0-9]{4}) ([0-9]{2}:[0-9]{2}:[0-9]{2})");
+    EXPECT_TRUE(boost::regex_match(result, expr));
+  }
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
It's Cpp part of formatter Based on PR https://github.com/ros/ros_comm/pull/1458 from ros_comm. Related to the https://github.com/ros/ros_comm/pull/1533 for Python.