### PR TITLE
remove MSVC special handling

### DIFF
--- a/src/rosconsole/rosconsole.cpp
+++ b/src/rosconsole/rosconsole.cpp
@@ -459,27 +459,14 @@ void initialize()
 
 void vformatToBuffer(boost::shared_array<char>& buffer, size_t& buffer_size, const char* fmt, va_list args)
 {
-#ifdef _MSC_VER
-  va_list arg_copy = args; // dangerous?
-#else
   va_list arg_copy;
   va_copy(arg_copy, args);
-#endif
-#ifdef _MSC_VER
-  size_t total = vsnprintf_s(buffer.get(), buffer_size, buffer_size, fmt, args);
-#else
   size_t total = vsnprintf(buffer.get(), buffer_size, fmt, args);
-#endif
   if (total >= buffer_size)
   {
     buffer_size = total + 1;
     buffer.reset(new char[buffer_size]);
-
-#ifdef _MSC_VER
-    vsnprintf_s(buffer.get(), buffer_size, buffer_size, fmt, arg_copy);
-#else
     vsnprintf(buffer.get(), buffer_size, fmt, arg_copy);
-#endif
   }
   va_end(arg_copy);
 }


### PR DESCRIPTION
remove the use of `vsnprintf_s` in `void vformatToBuffer()`, reasons are as followed:
- `vsnprintf` already specifies that ["the generated string has a length of at most `n-1`"](http://www.cplusplus.com/reference/cstdio/vsnprintf/), using the standard function across platforms improves simplicity and makes it easier to maintain
- we're guessing that this MSVC special handling was originally added because compiling with MSVC would [yield warning](https://stackoverflow.com/questions/17351874/is-vsnprintf-s-an-appropriate-replacement-for-deprecated-vsnprintf), but compiling with VS2017 does not give any error