### PR TITLE
dll import/export visibility macro update

### DIFF
--- a/include/ros/console_backend.h
+++ b/include/ros/console_backend.h
@@ -66,11 +66,11 @@ typedef levels::Level Level;
 namespace backend
 {
 
-void notifyLoggerLevelsChanged();
+ROSCONSOLE_BACKEND_DECL void notifyLoggerLevelsChanged();
 
 ROSCONSOLE_BACKEND_DECL extern void (*function_notifyLoggerLevelsChanged)();
 
-void print(void* logger_handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line);
+ROSCONSOLE_BACKEND_DECL void print(void* logger_handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line);
 
 ROSCONSOLE_BACKEND_DECL extern void (*function_print)(void*, ::ros::console::Level, const char*, const char*, const char*, int);
 

--- a/include/ros/console_impl.h
+++ b/include/ros/console_impl.h
@@ -33,6 +33,11 @@
 #include <ros/macros.h>
 #include "ros/console.h"
 
+// export interface functions shared by all impl instances in one single header
+// since CMake would not help define custome flag like ROSCONSOLE_CONSOLE_IMPL_EXPORTS,
+// the ROSCONSOLE_CONSOLE_IMPL_EXPORTS macro needs to be defined
+// in the impl code (e.g. rosconsole_log4css.cpp) before including this header
+
 // Import/export for windows dll's and visibility for gcc shared libraries.
 #ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
   #ifdef ROSCONSOLE_CONSOLE_IMPL_EXPORTS // we are building a shared lib/dll
@@ -43,7 +48,6 @@
 #else // ros is being built around static libraries
   #define ROSCONSOLE_CONSOLE_IMPL_DECL
 #endif
-
 
 // declare interface for rosconsole implementations
 namespace ros

--- a/include/ros/console_impl.h
+++ b/include/ros/console_impl.h
@@ -27,10 +27,25 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "ros/console.h"
-#define ROSCONSOLE_CONSOLE_IMPL_EXPORTS
-#include "ros/console_impl.h"
+#ifndef ROSCONSOLE_CONSOLE_IMPL_H
+#define ROSCONSOLE_CONSOLE_IMPL_H
 
+#include <ros/macros.h>
+#include "ros/console.h"
+
+// Import/export for windows dll's and visibility for gcc shared libraries.
+#ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
+  #ifdef ROSCONSOLE_CONSOLE_IMPL_EXPORTS // we are building a shared lib/dll
+    #define ROSCONSOLE_CONSOLE_IMPL_DECL ROS_HELPER_EXPORT
+  #else // we are using shared lib/dll
+    #define ROSCONSOLE_CONSOLE_IMPL_DECL ROS_HELPER_IMPORT
+  #endif
+#else // ros is being built around static libraries
+  #define ROSCONSOLE_CONSOLE_IMPL_DECL
+#endif
+
+
+// declare interface for rosconsole implementations
 namespace ros
 {
 namespace console
@@ -38,53 +53,26 @@ namespace console
 namespace impl
 {
 
-LogAppender* rosconsole_print_appender = 0;
+ROSCONSOLE_CONSOLE_IMPL_DECL void initialize();
 
-void initialize()
-{}
+ROSCONSOLE_CONSOLE_IMPL_DECL void shutdown();
 
-void print(void* handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line)
-{
-  ::ros::console::backend::print(0, level, str, file, function, line);
-  if(rosconsole_print_appender)
-  {
-    rosconsole_print_appender->log(level, str, file, function, line);
-  }
-}
+ROSCONSOLE_CONSOLE_IMPL_DECL void register_appender(LogAppender* appender);
 
-bool isEnabledFor(void* handle, ::ros::console::Level level)
-{
-  return level != ::ros::console::levels::Debug;
-}
+ROSCONSOLE_CONSOLE_IMPL_DECL void print(void* handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line);
 
-void* getHandle(const std::string& name)
-{
-  return 0;
-}
+ROSCONSOLE_CONSOLE_IMPL_DECL bool isEnabledFor(void* handle, ::ros::console::Level level);
 
-std::string getName(void* handle)
-{
-  return "";
-}
+ROSCONSOLE_CONSOLE_IMPL_DECL void* getHandle(const std::string& name);
 
-void register_appender(LogAppender* appender)
-{
-  rosconsole_print_appender = appender;
-}
+ROSCONSOLE_CONSOLE_IMPL_DECL std::string getName(void* handle);
 
-void shutdown()
-{}
+ROSCONSOLE_CONSOLE_IMPL_DECL bool get_loggers(std::map<std::string, levels::Level>& loggers);
 
-bool get_loggers(std::map<std::string, levels::Level>& loggers)
-{
-  return true;
-}
-
-bool set_logger_level(const std::string& name, levels::Level level)
-{
-  return false;
-}
+ROSCONSOLE_CONSOLE_IMPL_DECL bool set_logger_level(const std::string& name, levels::Level level);
 
 } // namespace impl
 } // namespace console
 } // namespace ros
+
+#endif // ROSCONSOLE_CONSOLE_IMPL_H

--- a/src/rosconsole/impl/rosconsole_glog.cpp
+++ b/src/rosconsole/impl/rosconsole_glog.cpp
@@ -1,4 +1,6 @@
 #include "ros/console.h"
+#define ROSCONSOLE_CONSOLE_IMPL_EXPORTS
+#include "ros/console_impl.h"
 
 #include <glog/logging.h>
 
@@ -16,8 +18,6 @@ void initialize()
 {
   google::InitGoogleLogging("rosconsole");
 }
-
-std::string getName(void* handle);
 
 void print(void* handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line)
 {

--- a/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -36,7 +36,6 @@
 #include "ros/console.h"
 #include "ros/assert.h"
 #include <ros/time.h>
-
 #define ROSCONSOLE_CONSOLE_IMPL_EXPORTS
 #include "ros/console_impl.h"
 
@@ -128,7 +127,7 @@ protected:
   }
 };
 
-ROSCONSOLE_LOG4CXX_DECL void initialize()
+void initialize()
 {
   // First set up some sane defaults programmatically.
   log4cxx::LoggerPtr ros_logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
@@ -180,7 +179,7 @@ ROSCONSOLE_LOG4CXX_DECL void initialize()
 }
 
 
-ROSCONSOLE_LOG4CXX_DECL void print(void* handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line)
+void print(void* handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line)
 {
   log4cxx::Logger* logger  = (log4cxx::Logger*)handle;
   try
@@ -193,18 +192,18 @@ ROSCONSOLE_LOG4CXX_DECL void print(void* handle, ::ros::console::Level level, co
   }
 }
 
-ROSCONSOLE_LOG4CXX_DECL bool isEnabledFor(void* handle, ::ros::console::Level level)
+bool isEnabledFor(void* handle, ::ros::console::Level level)
 {
   log4cxx::Logger* logger  = (log4cxx::Logger*)handle;
   return logger->isEnabledFor(g_level_lookup[level]);
 }
 
-ROSCONSOLE_LOG4CXX_DECL void* getHandle(const std::string& name)
+void* getHandle(const std::string& name)
 {
   return log4cxx::Logger::getLogger(name);
 }
 
-ROSCONSOLE_LOG4CXX_DECL std::string getName(void* handle)
+std::string getName(void* handle)
 {
   const log4cxx::spi::LoggingEvent* event = (const log4cxx::spi::LoggingEvent*)handle;
 #ifdef _MSC_VER
@@ -215,7 +214,7 @@ ROSCONSOLE_LOG4CXX_DECL std::string getName(void* handle)
 #endif
 }
 
-ROSCONSOLE_LOG4CXX_DECL bool get_loggers(std::map<std::string, levels::Level>& loggers)
+bool get_loggers(std::map<std::string, levels::Level>& loggers)
 {
   log4cxx::spi::LoggerRepositoryPtr repo = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME)->getLoggerRepository();
 
@@ -263,7 +262,7 @@ ROSCONSOLE_LOG4CXX_DECL bool get_loggers(std::map<std::string, levels::Level>& l
   return true;
 }
 
-ROSCONSOLE_LOG4CXX_DECL bool set_logger_level(const std::string& name, levels::Level level)
+bool set_logger_level(const std::string& name, levels::Level level)
 {
   log4cxx::LevelPtr log4cxx_level;
   if (level == levels::Debug)
@@ -351,14 +350,14 @@ protected:
 
 Log4cxxAppender* g_log4cxx_appender;
 
-ROSCONSOLE_LOG4CXX_DECL void register_appender(LogAppender* appender)
+void register_appender(LogAppender* appender)
 {
   g_log4cxx_appender = new Log4cxxAppender(appender);
   const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
   logger->addAppender(g_log4cxx_appender);
 }
 
-ROSCONSOLE_LOG4CXX_DECL void shutdown()
+void shutdown()
 {
   const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
   logger->removeAppender(g_log4cxx_appender);

--- a/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -36,16 +36,9 @@
 #include "ros/console.h"
 #include "ros/assert.h"
 #include <ros/time.h>
-#include <ros/macros.h>
-#ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
-  #ifdef rosconsole_log4cxx_EXPORTS // we are building a shared lib/dll
-    #define ROSCONSOLE_LOG4CXX_DECL ROS_HELPER_EXPORT
-  #else // we are using shared lib/dll
-    #define ROSCONSOLE_LOG4CXX_DECL ROS_HELPER_IMPORT
-  #endif
-#else // ros is being built around static libraries
-  #define ROSCONSOLE_LOG4CXX_DECL
-#endif
+
+#define ROSCONSOLE_CONSOLE_IMPL_EXPORTS
+#include "ros/console_impl.h"
 
 #include "log4cxx/appenderskeleton.h"
 #include "log4cxx/spi/loggingevent.h"

--- a/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -36,6 +36,17 @@
 #include "ros/console.h"
 #include "ros/assert.h"
 #include <ros/time.h>
+#include <ros/macros.h>
+#ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
+  #ifdef rosconsole_log4cxx_EXPORTS // we are building a shared lib/dll
+    #define ROSCONSOLE_LOG4CXX_DECL ROS_HELPER_EXPORT
+  #else // we are using shared lib/dll
+    #define ROSCONSOLE_LOG4CXX_DECL ROS_HELPER_IMPORT
+  #endif
+#else // ros is being built around static libraries
+  #define ROSCONSOLE_LOG4CXX_DECL
+#endif
+
 #include "log4cxx/appenderskeleton.h"
 #include "log4cxx/spi/loggingevent.h"
 #include "log4cxx/level.h"
@@ -124,7 +135,7 @@ protected:
   }
 };
 
-void initialize()
+ROSCONSOLE_LOG4CXX_DECL void initialize()
 {
   // First set up some sane defaults programmatically.
   log4cxx::LoggerPtr ros_logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
@@ -176,7 +187,7 @@ void initialize()
 }
 
 
-void print(void* handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line)
+ROSCONSOLE_LOG4CXX_DECL void print(void* handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line)
 {
   log4cxx::Logger* logger  = (log4cxx::Logger*)handle;
   try
@@ -189,18 +200,18 @@ void print(void* handle, ::ros::console::Level level, const char* str, const cha
   }
 }
 
-bool isEnabledFor(void* handle, ::ros::console::Level level)
+ROSCONSOLE_LOG4CXX_DECL bool isEnabledFor(void* handle, ::ros::console::Level level)
 {
   log4cxx::Logger* logger  = (log4cxx::Logger*)handle;
   return logger->isEnabledFor(g_level_lookup[level]);
 }
 
-void* getHandle(const std::string& name)
+ROSCONSOLE_LOG4CXX_DECL void* getHandle(const std::string& name)
 {
   return log4cxx::Logger::getLogger(name);
 }
 
-std::string getName(void* handle)
+ROSCONSOLE_LOG4CXX_DECL std::string getName(void* handle)
 {
   const log4cxx::spi::LoggingEvent* event = (const log4cxx::spi::LoggingEvent*)handle;
 #ifdef _MSC_VER
@@ -211,7 +222,7 @@ std::string getName(void* handle)
 #endif
 }
 
-bool get_loggers(std::map<std::string, levels::Level>& loggers)
+ROSCONSOLE_LOG4CXX_DECL bool get_loggers(std::map<std::string, levels::Level>& loggers)
 {
   log4cxx::spi::LoggerRepositoryPtr repo = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME)->getLoggerRepository();
 
@@ -259,7 +270,7 @@ bool get_loggers(std::map<std::string, levels::Level>& loggers)
   return true;
 }
 
-bool set_logger_level(const std::string& name, levels::Level level)
+ROSCONSOLE_LOG4CXX_DECL bool set_logger_level(const std::string& name, levels::Level level)
 {
   log4cxx::LevelPtr log4cxx_level;
   if (level == levels::Debug)
@@ -347,14 +358,14 @@ protected:
 
 Log4cxxAppender* g_log4cxx_appender;
 
-void register_appender(LogAppender* appender)
+ROSCONSOLE_LOG4CXX_DECL void register_appender(LogAppender* appender)
 {
   g_log4cxx_appender = new Log4cxxAppender(appender);
   const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
   logger->addAppender(g_log4cxx_appender);
 }
 
-void shutdown()
+ROSCONSOLE_LOG4CXX_DECL void shutdown()
 {
   const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
   logger->removeAppender(g_log4cxx_appender);

--- a/src/rosconsole/rosconsole.cpp
+++ b/src/rosconsole/rosconsole.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include "ros/console.h"
+#include "ros/console_impl.h"
 #include "ros/assert.h"
 #include <ros/time.h>
 
@@ -54,29 +55,6 @@ namespace ros
 {
 namespace console
 {
-namespace impl
-{
-
-void initialize();
-
-void shutdown();
-
-void register_appender(LogAppender* appender);
-
-void print(void* handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line);
-
-bool isEnabledFor(void* handle, ::ros::console::Level level);
-
-void* getHandle(const std::string& name);
-
-std::string getName(void* handle);
-
-bool get_loggers(std::map<std::string, levels::Level>& loggers);
-
-bool set_logger_level(const std::string& name, levels::Level level);
-
-} // namespace impl
-
 
 bool g_initialized = false;
 bool g_shutting_down = false;


### PR DESCRIPTION
further updates to support DLL import/export on Windows =)
- add missing `ROSCONSOLE_BACKEND_DECL` (from previous visibility change) for `console_backend.h`
- move `console_impl` functions shared by `log4cxx`, `glog`, `print` into one single header `console_impl.h` (and remove the function declarations from `rosconsole.cpp`)

as mentioned in the comments, the `ROSCONSOLE_CONSOLE_IMPL_DECL` macro is added to manage visibility for functions in the impl components in one centralized position. For the implementations (`src/rosconsole/impl/rosconsole_xxx.cpp`), `ROSCONSOLE_CONSOLE_IMPL_EXPORTS` needs to be defined in the .cpp file before including `console_impl.h` since these files are compiled to generate their own runtime binaries (dlls). Another way of achieving the same result would be to use independent visibility control macros for each implementation; however, that means more duplicated code and makes it harder to manage.

Another reason to use a centralized header is so that it'd be easier to notice when the declaration and definition have a mismatch (at compile time); otherwise, such mismatch would cause error at runtime, making it harder to spot.