### PR TITLE
Fix for upstream log4cxx

### DIFF
--- a/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -88,23 +88,23 @@ protected:
                       log4cxx::helpers::Pool&)
   {
     levels::Level level = levels::Count;
-    if (event->getLevel() == log4cxx::Level::getDebug())
+    if (event->getLevel()->toInt() == log4cxx::Level::DEBUG_INT)
     {
       level = levels::Debug;
     }
-    else if (event->getLevel() == log4cxx::Level::getInfo())
+    else if (event->getLevel()->toInt() == log4cxx::Level::INFO_INT)
     {
       level = levels::Info;
     }
-    else if (event->getLevel() == log4cxx::Level::getWarn())
+    else if (event->getLevel()->toInt() == log4cxx::Level::WARN_INT)
     {
       level = levels::Warn;
     }
-    else if (event->getLevel() == log4cxx::Level::getError())
+    else if (event->getLevel()->toInt() == log4cxx::Level::ERROR_INT)
     {
       level = levels::Error;
     }
-    else if (event->getLevel() == log4cxx::Level::getFatal())
+    else if (event->getLevel()->toInt() == log4cxx::Level::FATAL_INT)
     {
       level = levels::Fatal;
     }
@@ -230,25 +230,25 @@ bool get_loggers(std::map<std::string, levels::Level>& loggers)
       std::string name = (*it)->getName();
     #endif
 
-    const log4cxx::LevelPtr& log4cxx_level = (*it)->getEffectiveLevel();
+    int log4cxx_level = (*it)->getEffectiveLevel()->toInt();
     levels::Level level;
-    if (log4cxx_level == log4cxx::Level::getDebug())
+    if (log4cxx_level == log4cxx::Level::DEBUG_INT)
     {
       level = levels::Debug;
     }
-    else if (log4cxx_level == log4cxx::Level::getInfo())
+    else if (log4cxx_level == log4cxx::Level::INFO_INT)
     {
       level = levels::Info;
     }
-    else if (log4cxx_level == log4cxx::Level::getWarn())
+    else if (log4cxx_level == log4cxx::Level::WARN_INT)
     {
       level = levels::Warn;
     }
-    else if (log4cxx_level == log4cxx::Level::getError())
+    else if (log4cxx_level == log4cxx::Level::ERROR_INT)
     {
       level = levels::Error;
     }
-    else if (log4cxx_level == log4cxx::Level::getFatal())
+    else if (log4cxx_level == log4cxx::Level::FATAL_INT)
     {
       level = levels::Fatal;
     }
@@ -311,23 +311,23 @@ protected:
   {
     (void)pool;
     levels::Level level;
-    if (event->getLevel() == log4cxx::Level::getFatal())
+    if (event->getLevel()->toInt() == log4cxx::Level::FATAL_INT)
     {
       level = levels::Fatal;
     }
-    else if (event->getLevel() == log4cxx::Level::getError())
+    else if (event->getLevel()->toInt() == log4cxx::Level::ERROR_INT)
     {
       level = levels::Error;
     }
-    else if (event->getLevel() == log4cxx::Level::getWarn())
+    else if (event->getLevel()->toInt() == log4cxx::Level::WARN_INT)
     {
       level = levels::Warn;
     }
-    else if (event->getLevel() == log4cxx::Level::getInfo())
+    else if (event->getLevel()->toInt() == log4cxx::Level::INFO_INT)
     {
       level = levels::Info;
     }
-    else if (event->getLevel() == log4cxx::Level::getDebug())
+    else if (event->getLevel()->toInt() == log4cxx::Level::DEBUG_INT)
     {
       level = levels::Debug;
     }


### PR DESCRIPTION
Fixes empty log lines on the console with upstream version of log4cxx.

In upstream log4cxx the calls `log4cxx::Level::getDebug()`, etc. now return new pointers on every call.
See https://issues.apache.org/jira/browse/LOGCXX-394

This resulted in rosconsole `Formatter::print` being called with an invalid level (`levels::Count`)
and hence `color` was NULL and nothing printed (except the newline).

So instead of calling getDebug(), directly compare the integer level which works in the released version and upstream.
It should also be more efficient to directly compare integer level when the upstream version of log4cxx is used.

~~While here also change/fix console printer to print unknown levels.~~ see #34 