### PR TITLE
fix console printer to also print unknown levels

### DIFF
--- a/src/rosconsole/rosconsole.cpp
+++ b/src/rosconsole/rosconsole.cpp
@@ -335,7 +335,7 @@ void Formatter::init(const char* fmt)
 
 void Formatter::print(void* logger_handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line)
 {
-  const char* color = NULL;
+  const char* color = COLOR_RED;
   FILE* f = stdout;
 
   if (level == levels::Fatal)
@@ -361,8 +361,6 @@ void Formatter::print(void* logger_handle, ::ros::console::Level level, const ch
   {
     color = COLOR_GREEN;
   }
-
-  ROS_ASSERT(color != NULL);
 
   std::stringstream ss;
   ss << color;

--- a/src/rosconsole/rosconsole.cpp
+++ b/src/rosconsole/rosconsole.cpp
@@ -335,31 +335,31 @@ void Formatter::init(const char* fmt)
 
 void Formatter::print(void* logger_handle, ::ros::console::Level level, const char* str, const char* file, const char* function, int line)
 {
+  // print in red to stderr if level doesn't match any of the predefined ones
   const char* color = COLOR_RED;
-  FILE* f = stdout;
+  FILE* f = stderr;
 
   if (level == levels::Fatal)
   {
     color = COLOR_RED;
-    f = stderr;
   }
   else if (level == levels::Error)
   {
     color = COLOR_RED;
-    f = stderr;
   }
   else if (level == levels::Warn)
   {
     color = COLOR_YELLOW;
-    f = stderr;
   }
   else if (level == levels::Info)
   {
     color = COLOR_NORMAL;
+    f = stdout;
   }
   else if (level == levels::Debug)
   {
     color = COLOR_GREEN;
+    f = stdout;
   }
 
   std::stringstream ss;


### PR DESCRIPTION
this can happen if people added their own log4cxx levels
In this case, still print the message on the console in red with "UNKNO" level instead of just printing a newline.