### PR TITLE
declare specific boost dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>apr</build_depend>
-  <build_depend>boost</build_depend>
+  <build_depend>libboost-regex-dev</build_depend>
+  <build_depend>libboost-system-dev</build_depend>
+  <build_depend>libboost-thread-dev</build_depend>
   <build_depend>cpp_common</build_depend>
   <build_depend>log4cxx</build_depend>
   <build_depend>rostime</build_depend>


### PR DESCRIPTION
May be worth targeting to a noetic-devel to not impact released packages on other distributions

Depends on https://github.com/ros/rosdistro/pull/23620
related to https://github.com/ros/ros_comm/pull/1871