### PR TITLE
export boost-regex-dev for now

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
 
   <run_depend>apr</run_depend>
   <run_depend>cpp_common</run_depend>
-  <run_depend>libboost-regex</run_depend>
+  <run_depend>libboost-regex-dev</run_depend>
   <run_depend>log4cxx</run_depend>
   <run_depend>rosbuild</run_depend>
   <run_depend>rostime</run_depend>


### PR DESCRIPTION
The dev package `libboost-regex-dev` maps to a version specific package which is specific per platform: e.g. `libboost-regex<VERSION>-dev`.

Using that package from CMake results in linking against a library without a specific version number: e.g. `/usr/lib/x86_64-linux-gnu/libboost_regex.so`.

When only installing the non-dev package like `libboost-regex1.67.0` that only installs a library with a specific version suffix, e.g. `/usr/lib/x86_64-linux-gnu/libboost_regex.so.1.67.0`.

As a consequence downstream packages fail to link.

As a workaround for now this patch exports the dev package rather than the non-dev package.