### PR TITLE
make stderr  log to file

### DIFF
--- a/src/rosconsole/rosconsole.cpp
+++ b/src/rosconsole/rosconsole.cpp
@@ -426,8 +426,13 @@ void Formatter::print(void* logger_handle, ::ros::console::Level level, const ch
   ss << COLOR_NORMAL;
 
   fprintf(f, "%s\n", ss.str().c_str());
-  
-  if (g_force_stdout_line_buffered)
+
+  if (f == stderr)
+  {
+    fprintf(stdout, "%s\n", ss.str().c_str());
+  }
+
+  if (g_force_stdout_line_buffered && f == stdout)
   {
     int flush_result = fflush(f);
     if (flush_result != 0 && !g_stdout_flush_failure_reported)

--- a/src/rosconsole/rosconsole.cpp
+++ b/src/rosconsole/rosconsole.cpp
@@ -427,7 +427,7 @@ void Formatter::print(void* logger_handle, ::ros::console::Level level, const ch
 
   fprintf(f, "%s\n", ss.str().c_str());
   
-  if (g_force_stdout_line_buffered && f == stdout)
+  if (g_force_stdout_line_buffered)
   {
     int flush_result = fflush(f);
     if (flush_result != 0 && !g_stdout_flush_failure_reported)


### PR DESCRIPTION
I'm wondering why ROS_ERROR cannot be logged to log file?
In my case, I don't have an monitor,  so all thing should be logged. But all nodes ERR msgs are logged to rosout.log instead of indepandent node's log. it's hard to search.