### PR TITLE
Checking MSVC predefined macro.

### DIFF
--- a/include/ros/assert.h
+++ b/include/ros/assert.h
@@ -91,12 +91,10 @@
 
 #include <ros/platform.h>
 
-#ifdef WIN32
-# if defined (__MINGW32__)
-#  define ROS_ISSUE_BREAK() DebugBreak();
-# else // MSVC
-#  define ROS_ISSUE_BREAK() __debugbreak();
-# endif
+#if defined(__MINGW32__)
+# define ROS_ISSUE_BREAK() DebugBreak();
+#elif defined(_MSC_VER)
+# define ROS_ISSUE_BREAK() __debugbreak();
 #elif defined(__powerpc64__)
 # define ROS_ISSUE_BREAK() asm volatile ("tw 31,1,1");
 #elif defined(__i386__) || defined(__ia64__) || defined(__x86_64__)

--- a/include/ros/console.h
+++ b/include/ros/console.h
@@ -276,7 +276,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
 } // namespace console
 } // namespace ros
 
-#ifdef WIN32
+#if defined(_MSC_VER)
 #define ROS_LIKELY(x)       (x)
 #define ROS_UNLIKELY(x)     (x)
 #else
@@ -284,7 +284,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
 #define ROS_UNLIKELY(x)     __builtin_expect((x),0)
 #endif
 
-#if defined(MSVC)
+#if defined(_MSC_VER)
   #define __ROSCONSOLE_FUNCTION__ __FUNCSIG__
 #elif defined(__GNUC__)
   #define __ROSCONSOLE_FUNCTION__ __PRETTY_FUNCTION__

--- a/src/rosconsole/rosconsole.cpp
+++ b/src/rosconsole/rosconsole.cpp
@@ -73,7 +73,7 @@ log4cxx::LevelPtr g_level_lookup[levels::Count] =
 #endif
 std::string g_last_error_message = "Unknown Error";
 
-#ifdef WIN32
+#ifdef _WIN32
   #define COLOR_NORMAL ""
   #define COLOR_RED ""
   #define COLOR_GREEN ""


### PR DESCRIPTION
This change is to check the Windows platform and MSVC compiler by its [predefined macro](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019), such as `_MSC_VER` and `_WIN32`. This is motivated by consuming those header from non-CMake projects, where some macro, such as `MSVC` and `WIN32`, are not defined by default.

And please consider to back-port to `melodic` branch.