### PR TITLE
Fix for log4cxx 0.12.0

### DIFF
--- a/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -127,6 +127,8 @@ protected:
   }
 };
 
+LOG4CXX_PTR_DEF(ROSConsoleStdioAppender);
+
 void initialize()
 {
   // First set up some sane defaults programmatically.
@@ -166,7 +168,7 @@ void initialize()
   }
 
   log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
-  logger->addAppender(new ROSConsoleStdioAppender);
+  logger->addAppender(ROSConsoleStdioAppenderPtr(new ROSConsoleStdioAppender()));
 #ifdef _MSC_VER
   if ( ros_root_cstr != NULL ) {
 	  free(ros_root_cstr);
@@ -200,7 +202,7 @@ bool isEnabledFor(void* handle, ::ros::console::Level level)
 
 void* getHandle(const std::string& name)
 {
-  return log4cxx::Logger::getLogger(name);
+  return log4cxx::Logger::getLogger(name).get();
 }
 
 std::string getName(void* handle)
@@ -216,7 +218,7 @@ std::string getName(void* handle)
 
 bool get_loggers(std::map<std::string, levels::Level>& loggers)
 {
-  log4cxx::spi::LoggerRepositoryPtr repo = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME)->getLoggerRepository();
+  log4cxx::spi::LoggerRepositoryPtr repo = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME)->getLoggerRepository().lock();
 
   log4cxx::LoggerList current_loggers = repo->getCurrentLoggers();
   log4cxx::LoggerList::iterator it = current_loggers.begin();
@@ -352,20 +354,21 @@ protected:
   ros::console::LogAppender* appender_;
 };
 
+LOG4CXX_PTR_DEF(Log4cxxAppender);
 Log4cxxAppender* g_log4cxx_appender = 0;
 
 void register_appender(LogAppender* appender)
 {
   g_log4cxx_appender = new Log4cxxAppender(appender);
   const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
-  logger->addAppender(g_log4cxx_appender);
+  logger->addAppender(Log4cxxAppenderPtr(g_log4cxx_appender));
 }
 
 void deregister_appender(LogAppender* appender){
   if(g_log4cxx_appender->getAppender() == appender)
   {
     const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
-    logger->removeAppender(g_log4cxx_appender);
+    logger->removeAppender(Log4cxxAppenderPtr(g_log4cxx_appender));
     delete g_log4cxx_appender;
     g_log4cxx_appender = 0;
   }
@@ -375,7 +378,7 @@ void shutdown()
   if(g_log4cxx_appender)
   {
     const log4cxx::LoggerPtr& logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
-    logger->removeAppender(g_log4cxx_appender);
+    logger->removeAppender(Log4cxxAppenderPtr(g_log4cxx_appender));
     g_log4cxx_appender = 0;
   }
   // reset this so that the logger doesn't get crashily destroyed
@@ -383,7 +386,7 @@ void shutdown()
   //
   // See https://code.ros.org/trac/ros/ticket/3271
   //
-  log4cxx::Logger::getRootLogger()->getLoggerRepository()->shutdown();
+  log4cxx::Logger::getRootLogger()->getLoggerRepository().lock()->shutdown();
 }
 
 } // namespace impl


### PR DESCRIPTION
I know Ubuntu will stuck with log4cxx 0.11.0. This PR is just for documentation and patch of bleeding edge Arch Linux 