### PR TITLE
Remove undesired blank spaces

### DIFF
--- a/src/rosconsole/rosconsole.cpp
+++ b/src/rosconsole/rosconsole.cpp
@@ -158,11 +158,11 @@ struct SeverityToken : public Token
     }
     else if (level == levels::Warn)
     {
-      return " WARN";
+      return "WARN";
     }
     else if (level == levels::Info)
     {
-      return " INFO";
+      return "INFO";
     }
     else if (level == levels::Debug)
     {


### PR DESCRIPTION
If I understand it correctly, we want to show the logging in the console like

```
[INFO] [1630659023.150800919]: ...
```

instead of 

```
[ INFO] [1630659023.150800919]: ...
```

This PR removed the undesired blank space before "INFO".

---

Besides, I would like to merge this change also into `melodic-devel` so that it can be fetched later via `apt upgrade`. Should I create another PR for that?