### PR TITLE
Added feature to enable or disable logs through service call

### DIFF
--- a/src/rosconsole/impl/rosconsole_log4cxx.cpp
+++ b/src/rosconsole/impl/rosconsole_log4cxx.cpp
@@ -252,6 +252,10 @@ bool get_loggers(std::map<std::string, levels::Level>& loggers)
     {
       level = levels::Fatal;
     }
+    else if (log4cxx_level == log4cxx::Level::OFF_INT)
+    {
+      level = levels::Info;
+    }
     else
     {
       return false;
@@ -289,8 +293,19 @@ bool set_logger_level(const std::string& name, levels::Level level)
   {
     return false;
   }
-
-  log4cxx::LoggerPtr logger = log4cxx::Logger::getLogger(name);
+ 
+  log4cxx::LoggerPtr logger;
+  if(name == "disable"){ 
+    logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
+    log4cxx_level = log4cxx::Level::getOff();
+  }
+  else if(name == "enable"){ 
+    logger = log4cxx::Logger::getLogger(ROSCONSOLE_ROOT_LOGGER_NAME);
+  }
+  else{
+    logger= log4cxx::Logger::getLogger(name);
+  }
+  
   logger->setLevel(log4cxx_level);
   ::ros::console::backend::notifyLoggerLevelsChanged();
   return true;


### PR DESCRIPTION
**Issue aimed**
Basically right now there is no way to stop logging during the runtime of roscpp node ,event though using service call one cannot disable logs, they can only change the log level of the node.
So to overcome this issue I have basically added a feature to enable/disable logs for any roscpp node using base service `set_logger_level`.

**Approach**
To enable/disable logs, one has to pass enable/disable parameter in logger, part of service request.
_Sample Service call to disable logging_
`rosservice call /node_name/set_logger_level "logger: 'disable' level: 'info'" `
This will make sure no logs will get dump.

To enable back logs, one has to pass `enable` as a logger or `ros`
Example:
`rosservice call /node_name/set_logger_level "logger: 'ros' level: 'info'" `
or using enable parameter
`rosservice call /node_name/set_logger_level "logger: 'enable' level: 'info'" `

**In Progress**
We have already raised a PR for rospy part, so that any node can be disable using service call.